### PR TITLE
Fix contact form URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -547,7 +547,7 @@
       <!-- Contact -->
       <section id="contact">
          <h2 class="section-title">Get in Touch</h2>
-         <form action="https://formspree.io/f/yourformid" method="POST">
+         <form action="https://formspree.io/f/xkgjajga" method="POST">
             <input
                type="text"
                name="name"


### PR DESCRIPTION
## Summary
- update contact form action to use real Formspree URL

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849e71591c08326b155b14a99f28408