### PR TITLE
Add vercel.json to specify Node 18 runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "functions": { "api/*.js": { "runtime": "nodejs18.x" } }
+}


### PR DESCRIPTION
## Summary
- specify Node.js 18 for serverless functions via `vercel.json`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6849e8ea95a48326837337557b1ef42f