### PR TITLE
Add Python & Data Science landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
                      <!-- <div id="paypal-button-container-ml" style="margin-top: 1rem;"></div> -->
                   </div>
                </div>
-               <div class="subject-card">
+               <a href="python-data-science.html" class="subject-card">
                   <img
                      src="assets/img/python_da_ad_card.png"
                      alt="Python code editor"
@@ -165,7 +165,7 @@
                      </p>
                      <span class="price">From $55/hr</span>
                   </div>
-               </div>
+               </a>
                <div class="subject-card">
                   <img
                      src="assets/img/mechanical_engineering_ad_card.png"

--- a/python-data-science.html
+++ b/python-data-science.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Python &amp; Data Science | Ali Jabbary</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&amp;display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-pb6qQyK5EzB4MZC8BvA/6vNJMkRJ8N6gXl7B+9i1kqdR6Y+uhQevFWFe16T9DzF1zJo1Ge3+Rl4rX9xkTx6Npg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <!-- Favicon -->
+    <link rel="icon" href="assets/img/favicon-aj.png" type="image/png" />
+    <link rel="shortcut icon" href="assets/img/favicon-aj.png" type="image/png" />
+  </head>
+  <body>
+    <!-- Header -->
+    <header class="header">
+      <a href="index.html" class="logo" aria-label="Home">
+        <div class="logo-wrapper" oncontextmenu="return false;">
+          <img src="assets/img/ali-jabbary-logo.png" alt="Ali Jabbary Logo" oncontextmenu="return false;" style="height: 42px; width: auto;" />
+          <div class="logo-overlay" oncontextmenu="return false;"></div>
+        </div>
+      </a>
+      <nav class="nav">
+        <input type="checkbox" id="menu-toggle" />
+        <label for="menu-toggle" class="menu-icon">&#9776;</label>
+        <ul class="menu">
+          <li><a href="index.html#subjects">Topics</a></li>
+          <li><a href="index.html#about">About</a></li>
+          <li><a href="index.html#testimonials">Testimonials</a></li>
+          <li><a href="index.html#resources">Resources</a></li>
+          <li><a href="book.html" target="_blank" class="btn">Book Call</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <!-- Hero with Image -->
+    <section class="hero">
+      <span class="shape one"></span>
+      <span class="shape two"></span>
+      <h1>Python &amp; Data Science Tutoring</h1>
+      <img src="assets/img/python_da_ad_card.png" alt="Python &amp; Data Science" style="max-width:100%; height:auto; margin-top:2rem; border-radius: var(--radius);" />
+    </section>
+
+    <!-- Topics Section -->
+    <section id="topics">
+      <h2 class="section-title">Topics Covered</h2>
+      <ul style="max-width:600px; margin:0 auto; line-height:1.8; font-size:1.1rem;">
+        <li>Wrangling</li>
+        <li>Visualization</li>
+        <li>Automation</li>
+      </ul>
+      <div style="text-align:center; margin-top:2rem; display:flex; gap:1rem; justify-content:center; flex-wrap:wrap;">
+        <a href="book.html?subject=python-data" class="btn">Start Class</a>
+        <a href="book.html?subject=python-data" class="btn">Book a Session</a>
+      </div>
+    </section>
+
+    <!-- Footer -->
+    <footer>
+      <p>&copy; <span id="year"></span> Ali Jabbary. All rights reserved.</p>
+      <div>
+        <a href="https://linkedin.com/" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
+        <a href="https://github.com/" aria-label="GitHub"><i class="fab fa-github"></i></a>
+        <a href="mailto:Light.knight32@gmail.com" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
+      </div>
+    </footer>
+
+    <!-- Back to top & scripts -->
+    <button onclick="window.scrollTo({top:0,behavior:'smooth'})" class="back-to-top">↑</button>
+    <script src="assets/js/main.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- create dedicated `python-data-science.html` with hero image, topics list, and booking buttons.
- wrap Python & Data Science card on home page with link to the new page.

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_688faa497b508326b449a279dce3bdab