### PR TITLE
Add Mechanical Engineering page and link from home

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
                      <span class="price">From $55/hr</span>
                   </div>
                </div>
-               <div class="subject-card">
+               <a href="mechanical-engineering.html" class="subject-card">
                   <img
                      src="assets/img/mechanical_engineering_ad_card.png"
                      alt="Mechanical Engineering design"
@@ -178,7 +178,7 @@
                      </p>
                      <span class="price">From $65/hr</span>
                   </div>
-               </div>
+               </a>
                <div class="subject-card">
                   <img
                      src="assets/img/excel_data_analysis_ad_card.png"

--- a/mechanical-engineering.html
+++ b/mechanical-engineering.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+   <head>
+      <!-- Basic SEO Meta Tags -->
+      <meta charset="UTF-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>Ali Jabbary</title>
+      <meta
+         name="description"
+         content="Future‑proof your career with Ali Jabbary – award‑winning data scientist, engineer & business strategist delivering elite 1‑on‑1 tutoring across STEM, finance and tech."
+         />
+      <meta property="og:title" content="Ali Jabbary | Elite Tutoring & Consulting" />
+      <meta property="og:description" content="Future‑proof your career with Ali Jabbary – award‑winning data scientist, engineer & business strategist delivering elite 1‑on‑1 tutoring across STEM, finance and tech." />
+      <meta
+         name="keywords"
+         content="Ali Jabbary tutor, math tutoring, physics tutor, data science mentor, machine learning coach, python tutor, mechanical engineering help, finance tutoring, CAD tutor, ANSYS, SolidWorks, LLM, AutoCAD, accounting tutor, algebra tutor"
+         />
+      <link rel="canonical" href="https://alijabbary.com/" />
+      <meta name="robots" content="index, follow" />
+      <!-- Open Graph -->
+      <meta
+         property="og:title"
+         content="Ali Jabbary | Premier Multidisciplinary Tutoring & Consulting"
+         />
+      <meta
+         property="og:description"
+         content="Hands‑on 1‑on‑1 guidance in Math, Engineering, AI, Finance & more. Book your free strategy call today!"
+         />
+      <meta
+         property="og:image"
+         content="assets/img/ali-jabbary-logo.png"
+         />
+      <meta property="og:url" content="https://alijabbary.com/" />
+      <meta property="og:type" content="website" />
+      <link rel="stylesheet" href="assets/css/styles.css" />
+      <!-- Favicon -->
+      <link rel="icon" href="assets/img/favicon-aj.png" type="image/png" />
+      <!-- Optional for better compatibility -->
+      <link rel="shortcut icon" href="assets/img/favicon-aj.png" type="image/png" />
+      <!-- Main Logo for social/preview -->
+      <meta property="og:image" content="assets/img/ali-jabbary-logo.png" />
+      <!-- Fonts & Icons -->
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+      <link
+         href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap"
+         rel="stylesheet"
+         />
+      <link
+         rel="stylesheet"
+         href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+         integrity="sha512-pb6qQyK5EzB4MZC8BvA/6vNJMkRJ8N6gXl7B+9i1kqdR6Y+uhQevFWFe16T9DzF1zJo1Ge3+Rl4rX9xkTx6Npg=="
+         crossorigin="anonymous"
+         referrerpolicy="no-referrer"
+         />
+      <!-- Google tag (gtag.js) -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=G-PF85DJLT1P"></script>
+      <script type="application/ld+json">
+         {
+           "@context": "https://schema.org",
+           "@type": "LocalBusiness",
+           "name": "Ali Jabbary Tutoring",
+           "description": "Award-winning tutor offering personalized instruction across STEM, finance and technology.",
+           "url": "https://alijabbary.com/",
+           "logo": "https://alijabbary.com/assets/img/ali-jabbary-logo.png",
+           "image": "https://alijabbary.com/assets/img/ali-jabbary-logo.png",
+           "sameAs": [
+             "https://linkedin.com/",
+             "https://github.com/"
+           ],
+           "address": {
+             "@type": "PostalAddress",
+             "addressLocality": "Toronto",
+             "addressRegion": "ON",
+             "addressCountry": "CA"
+           },
+           "contactPoint": {
+             "@type": "ContactPoint",
+             "contactType": "customer support",
+             "email": "Light.knight32@gmail.com"
+           }
+         }
+      </script>
+   </head>
+   <body>
+      <!-- Header -->
+      <header class="header">
+         <a href="index.html" class="logo" aria-label="Home">
+           <div class="logo-wrapper">
+             <img src="assets/img/ali-jabbary-logo.png" alt="Ali Jabbary Logo" style="height: 42px;" />
+           </div>
+         </a>
+         <nav class="nav">
+           <input type="checkbox" id="menu-toggle" />
+           <label for="menu-toggle" class="menu-icon">&#9776;</label>
+           <ul class="menu">
+             <li><a href="index.html#subjects">Topics</a></li>
+             <li><a href="index.html#about">About</a></li>
+             <li><a href="index.html#testimonials">Testimonials</a></li>
+             <li><a href="index.html#resources">Resources</a></li>
+             <li><a href="book.html" class="btn">Book Call</a></li>
+           </ul>
+         </nav>
+      </header>
+
+      <main>
+         <section class="hero">
+            <img src="assets/img/mechanical_engineering_ad_card.png" alt="Mechanical Engineering promotional graphic" />
+         </section>
+         <section class="course-overview">
+            <h1>Mechanical Engineering</h1>
+            <p>
+               Build real-world mechanical engineering expertise from thermodynamics and heat transfer to CAD/CAE and finite element analysis. Whether you're tackling coursework or prototyping a design, get hands-on guidance tailored to your goals.
+            </p>
+            <ul>
+               <li>Thermodynamics, heat transfer, and energy systems</li>
+               <li>Finite Element Method (FEM) and stress analysis</li>
+               <li>CAD/CAE tools like SolidWorks, ANSYS &amp; Fusion 360</li>
+               <li>Dynamics, controls, and mechanical design optimization</li>
+            </ul>
+            <div class="cta-group">
+               <a class="btn" href="book.html?subject=mechanical-engineering">Start Class</a>
+               <a class="btn" href="book.html?subject=mechanical-engineering">Reserve a Session</a>
+            </div>
+         </section>
+      </main>
+
+      <!-- Footer -->
+      <footer>
+         <p>&copy; <span id="year"></span> Ali Jabbary. All rights reserved.</p>
+         <div>
+           <a href="https://linkedin.com/" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
+           <a href="https://github.com/" aria-label="GitHub"><i class="fab fa-github"></i></a>
+           <a href="mailto:Light.knight32@gmail.com" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
+         </div>
+      </footer>
+      <!-- At the end of body -->
+      <button onclick="window.scrollTo({top:0,behavior:'smooth'})" class="back-to-top">↑</button>
+      <script src="assets/js/main.js"></script>
+   </body>
+</html>
+


### PR DESCRIPTION
## Summary
- add dedicated Mechanical Engineering subject page with shared layout and booking CTAs
- link home page Mechanical Engineering card to the new subject page

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688fad8d606c8326911369aca4785926