### PR TITLE
chore: expand Vercel function pattern

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
   "version": 2,
-  "functions": { "api/*.js": { "runtime": "nodejs18.x" } }
+  "functions": { "api/**/*.js": { "runtime": "nodejs18.x" } }
 }


### PR DESCRIPTION
## Summary
- ensure all nested API functions run on Node.js 18 by changing Vercel config to `api/**/*.js`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vercel --prod` *(fails: requires login credentials)*

------
https://chatgpt.com/codex/tasks/task_e_688fb4e68c64832680458546bef8b982