### PR TITLE
Fix header overlay blocking navigation links

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -160,11 +160,12 @@
   }
 
   .logo-wrapper {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	min-width: 120px; /* Optional, protects against tiny logos */
-	max-width: 100%;  /* Prevents overflowing */
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 120px; /* Optional, protects against tiny logos */
+        max-width: 100%;  /* Prevents overflowing */
+        position: relative; /* Scope overlay to logo bounds */
   }
   
   .logo-wrapper img {


### PR DESCRIPTION
## Summary
- Scope logo overlay to its container so it no longer intercepts header navigation clicks

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dd1b2ef7c8326a23368f232d6e80a