### PR TITLE
Add 2025 tech blog posts

### DIFF
--- a/assets/js/blog-data.js
+++ b/assets/js/blog-data.js
@@ -1,21 +1,24 @@
 const blogPosts = [
   {
     title: "OpenAI's Multimodal GPT-5 Reshapes Creation in 2025",
-    date: "2025-04-18",
+    date: "2025-04-18T09:00:00-04:00",
+    displayDate: "April 18, 2025 9:00 AM EST",
     image: "https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d?auto=format&fit=crop&w=600&q=80",
     excerpt: "GPT‑5 blends text, vision and audio with a 128k context window and real‑time tools.",
     filename: "openai-multimodal-gpt5.html"
   },
   {
     title: "Python 3.13 & Polars 1.32: Data Science's Fast Lane",
-    date: "2025-08-20",
+    date: "2025-08-20T10:00:00-04:00",
+    displayDate: "August 20, 2025 10:00 AM EST",
     image: "https://images.unsplash.com/photo-1517433456452-f9633a875f6f?auto=format&fit=crop&w=600&q=80",
     excerpt: "A new REPL, leaner stdlib and a blazing‑fast DataFrame engine define this year's stack.",
     filename: "python-polars-2025.html"
   },
   {
     title: "AI in Finance: Navigating 2025's New Regulatory Landscape",
-    date: "2025-09-05",
+    date: "2025-09-05T11:30:00-04:00",
+    displayDate: "September 5, 2025 11:30 AM EST",
     image: "https://images.unsplash.com/photo-1581091012184-5c1b46d0155b?auto=format&fit=crop&w=600&q=80",
     excerpt: "Global watchdogs now demand audit trails, risk checks and human oversight for AI models.",
     filename: "ai-finance-regulations-2025.html"

--- a/assets/js/blog-data.js
+++ b/assets/js/blog-data.js
@@ -1,0 +1,26 @@
+const blogPosts = [
+  {
+    title: "OpenAI's Multimodal GPT-5 Reshapes Creation in 2025",
+    date: "2025-04-18",
+    image: "https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d?auto=format&fit=crop&w=600&q=80",
+    excerpt: "GPT‑5 blends text, vision and audio with a 128k context window and real‑time tools.",
+    filename: "openai-multimodal-gpt5.html"
+  },
+  {
+    title: "Python 3.13 & Polars 1.32: Data Science's Fast Lane",
+    date: "2025-08-20",
+    image: "https://images.unsplash.com/photo-1517433456452-f9633a875f6f?auto=format&fit=crop&w=600&q=80",
+    excerpt: "A new REPL, leaner stdlib and a blazing‑fast DataFrame engine define this year's stack.",
+    filename: "python-polars-2025.html"
+  },
+  {
+    title: "AI in Finance: Navigating 2025's New Regulatory Landscape",
+    date: "2025-09-05",
+    image: "https://images.unsplash.com/photo-1581091012184-5c1b46d0155b?auto=format&fit=crop&w=600&q=80",
+    excerpt: "Global watchdogs now demand audit trails, risk checks and human oversight for AI models.",
+    filename: "ai-finance-regulations-2025.html"
+  }
+];
+
+// expose globally
+window.blogPosts = blogPosts;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -80,13 +80,21 @@ startAutoScroll();
 // Back-To-Top Button Functionality
 // ==============================
 const backToTopBtn = document.querySelector('.back-to-top');
-window.addEventListener('scroll', () => {
-  if (window.scrollY > 300) {
-    backToTopBtn.classList.add('show');
-  } else {
-    backToTopBtn.classList.remove('show');
-  }
-});
+if (backToTopBtn) {
+  window.addEventListener('scroll', () => {
+    if (window.scrollY > 300) {
+      backToTopBtn.classList.add('show');
+    } else {
+      backToTopBtn.classList.remove('show');
+    }
+  });
+}
+
+document.querySelectorAll('.back-to-top').forEach(btn =>
+  btn.addEventListener('click', () =>
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  )
+);
 
 
 // ==============================

--- a/blog/ai-finance-regulations-2025.html
+++ b/blog/ai-finance-regulations-2025.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI in Finance: Navigating 2025's New Regulatory Landscape</title>
+    <meta name="description" content="Governments tighten oversight on algorithmic decision making. Here's what finance teams need to know." />
+    <meta property="og:title" content="AI in Finance: Navigating 2025's New Regulatory Landscape" />
+    <meta property="og:description" content="From the EU AI Act to SEC audits, AI-driven finance now faces stricter accountability." />
+    <meta property="og:image" content="https://images.unsplash.com/photo-1581091012184-5c1b46d0155b?auto=format&fit=crop&w=1350&q=80" />
+    <link rel="stylesheet" href="../assets/css/styles.css" />
+    <link rel="icon" href="../assets/img/favicon-aj.png" type="image/png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-pb6qQyK5EzB4MZC8BvA/6vNJMkRJ8N6gXl7B+9i1kqdR6Y+uhQevFWFe16T9DzF1zJo1Ge3+Rl4rX9xkTx6Npg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  </head>
+  <body>
+    <header class="header">
+      <a href="../index.html" class="logo" aria-label="Home">
+        <div class="logo-wrapper">
+          <img src="../assets/img/ali-jabbary-logo.png" alt="Ali Jabbary Logo" style="height:42px;" />
+        </div>
+      </a>
+      <nav class="nav">
+        <input type="checkbox" id="menu-toggle" />
+        <label for="menu-toggle" class="menu-icon">&#9776;</label>
+        <ul class="menu">
+          <li><a href="../index.html#subjects">Topics</a></li>
+          <li><a href="../index.html#about">About</a></li>
+          <li><a href="../index.html#testimonials">Testimonials</a></li>
+          <li><a href="../index.html#resources">Resources</a></li>
+          <li><a href="../book.html" class="btn">Book Call</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <article class="blog-post">
+        <h1>AI in Finance: Navigating 2025's New Regulatory Landscape</h1>
+        <p class="post-meta">September 5, 2025</p>
+        <img src="https://images.unsplash.com/photo-1581091012184-5c1b46d0155b?auto=format&fit=crop&w=1350&q=80" alt="Finance data dashboard" />
+        <p>
+          Regulators worldwide spent 2024 drafting guardrails for AI and those
+          rules start biting this year. The EU’s AI Act now requires banks to
+          perform rigorous risk assessments on any model that influences credit or
+          investment decisions. Across the Atlantic, the U.S. Securities and
+          Exchange Commission is rolling out audit trails for algorithmic trading
+          systems.
+        </p>
+        <p>
+          Firms must document training data sources, monitor model drift and
+          provide human override mechanisms for high‑stakes calls. Non‑compliance
+          carries steep fines and reputational damage.
+        </p>
+        <p>
+          For finance teams embracing AI, the message is clear: pair innovation
+          with governance. Establish model registers, run red‑team exercises and
+          keep humans in the loop.
+        </p>
+        <div class="cta-group">
+          <a class="btn" href="../book.html?subject=corporate-finance">Audit My Models</a>
+          <a class="btn" href="../book.html">Talk Compliance Strategy</a>
+        </div>
+      </article>
+    </main>
+    <footer>
+      <p>&copy; <span id="year"></span> Ali Jabbary. All rights reserved.</p>
+      <div>
+        <a href="https://linkedin.com/" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
+        <a href="https://github.com/" aria-label="GitHub"><i class="fab fa-github"></i></a>
+        <a href="mailto:Light.knight32@gmail.com" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
+      </div>
+    </footer>
+    <button onclick="window.scrollTo({top:0,behavior:'smooth'})" class="back-to-top">↑</button>
+    <script src="../assets/js/main.js"></script>
+  </body>
+</html>

--- a/blog/ai-finance-regulations-2025.html
+++ b/blog/ai-finance-regulations-2025.html
@@ -19,7 +19,7 @@
     <header class="header">
       <a href="../index.html" class="logo" aria-label="Home">
         <div class="logo-wrapper">
-          <img src="../assets/img/ali-jabbary-logo.png" alt="Ali Jabbary Logo" style="height:42px;" />
+          <img src="../assets/img/ali-jabbary-logo.png" alt="Ali Jabbary Logo" />
         </div>
       </a>
       <nav class="nav">
@@ -37,7 +37,7 @@
     <main>
       <article class="blog-post">
         <h1>AI in Finance: Navigating 2025's New Regulatory Landscape</h1>
-        <p class="post-meta">September 5, 2025</p>
+        <p class="post-meta">September 5, 2025 11:30 AM EST</p>
         <img src="https://images.unsplash.com/photo-1581091012184-5c1b46d0155b?auto=format&fit=crop&w=1350&q=80" alt="Finance data dashboard" />
         <p>
           Regulators worldwide spent 2024 drafting guardrails for AI and those
@@ -68,10 +68,10 @@
       <div>
         <a href="https://linkedin.com/" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
         <a href="https://github.com/" aria-label="GitHub"><i class="fab fa-github"></i></a>
-        <a href="mailto:Light.knight32@gmail.com" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
+        <a href="mailto:contact@alijabbary.com" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
       </div>
     </footer>
-    <button onclick="window.scrollTo({top:0,behavior:'smooth'})" class="back-to-top">↑</button>
+    <button class="back-to-top">↑</button>
     <script src="../assets/js/main.js"></script>
   </body>
 </html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -16,7 +16,7 @@
     <header class="header">
       <a href="../index.html" class="logo" aria-label="Home">
         <div class="logo-wrapper">
-          <img src="../assets/img/ali-jabbary-logo.png" alt="Ali Jabbary Logo" style="height:42px;" />
+          <img src="../assets/img/ali-jabbary-logo.png" alt="Ali Jabbary Logo" />
         </div>
       </a>
       <nav class="nav">
@@ -39,19 +39,41 @@
       <div>
         <a href="https://linkedin.com/" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
         <a href="https://github.com/" aria-label="GitHub"><i class="fab fa-github"></i></a>
-        <a href="mailto:Light.knight32@gmail.com" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
+        <a href="mailto:contact@alijabbary.com" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
       </div>
     </footer>
-    <button onclick="window.scrollTo({top:0,behavior:'smooth'})" class="back-to-top">↑</button>
+    <button class="back-to-top">↑</button>
     <script src="../assets/js/blog-data.js"></script>
     <script>
       const container = document.getElementById('blog-list');
-      blogPosts.forEach(post => {
-        const article = document.createElement('article');
-        article.className = 'blog-card';
-        article.innerHTML = `\n          <a href="${post.filename}">\n            <img src="${post.image}" alt="${post.title}" />\n            <h2>${post.title}</h2>\n            <p>${post.excerpt}</p>\n            <span class="date">${post.date}</span>\n          </a>\n        `;
-        container.appendChild(article);
-      });
+      blogPosts
+        .slice()
+        .sort((a, b) => new Date(b.date) - new Date(a.date))
+        .forEach(post => {
+          const article = document.createElement('article');
+          article.className = 'blog-card';
+
+          const link = document.createElement('a');
+          link.href = post.filename;
+
+          const img = document.createElement('img');
+          img.src = post.image;
+          img.alt = post.title;
+
+          const h2 = document.createElement('h2');
+          h2.textContent = post.title;
+
+          const p = document.createElement('p');
+          p.textContent = post.excerpt;
+
+          const dateSpan = document.createElement('span');
+          dateSpan.className = 'date';
+          dateSpan.textContent = post.displayDate;
+
+          link.append(img, h2, p, dateSpan);
+          article.appendChild(link);
+          container.appendChild(article);
+        });
     </script>
     <script src="../assets/js/main.js"></script>
   </body>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blog | Ali Jabbary</title>
+    <meta name="description" content="Latest articles on AI, programming and finance from Ali Jabbary." />
+    <link rel="stylesheet" href="../assets/css/styles.css" />
+    <link rel="icon" href="../assets/img/favicon-aj.png" type="image/png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-pb6qQyK5EzB4MZC8BvA/6vNJMkRJ8N6gXl7B+9i1kqdR6Y+uhQevFWFe16T9DzF1zJo1Ge3+Rl4rX9xkTx6Npg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  </head>
+  <body>
+    <header class="header">
+      <a href="../index.html" class="logo" aria-label="Home">
+        <div class="logo-wrapper">
+          <img src="../assets/img/ali-jabbary-logo.png" alt="Ali Jabbary Logo" style="height:42px;" />
+        </div>
+      </a>
+      <nav class="nav">
+        <input type="checkbox" id="menu-toggle" />
+        <label for="menu-toggle" class="menu-icon">&#9776;</label>
+        <ul class="menu">
+          <li><a href="../index.html#subjects">Topics</a></li>
+          <li><a href="../index.html#about">About</a></li>
+          <li><a href="../index.html#testimonials">Testimonials</a></li>
+          <li><a href="../index.html#resources">Resources</a></li>
+          <li><a href="../book.html" class="btn">Book Call</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <section id="blog-list" class="blog-list"></section>
+    </main>
+    <footer>
+      <p>&copy; <span id="year"></span> Ali Jabbary. All rights reserved.</p>
+      <div>
+        <a href="https://linkedin.com/" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
+        <a href="https://github.com/" aria-label="GitHub"><i class="fab fa-github"></i></a>
+        <a href="mailto:Light.knight32@gmail.com" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
+      </div>
+    </footer>
+    <button onclick="window.scrollTo({top:0,behavior:'smooth'})" class="back-to-top">↑</button>
+    <script src="../assets/js/blog-data.js"></script>
+    <script>
+      const container = document.getElementById('blog-list');
+      blogPosts.forEach(post => {
+        const article = document.createElement('article');
+        article.className = 'blog-card';
+        article.innerHTML = `\n          <a href="${post.filename}">\n            <img src="${post.image}" alt="${post.title}" />\n            <h2>${post.title}</h2>\n            <p>${post.excerpt}</p>\n            <span class="date">${post.date}</span>\n          </a>\n        `;
+        container.appendChild(article);
+      });
+    </script>
+    <script src="../assets/js/main.js"></script>
+  </body>
+</html>

--- a/blog/openai-multimodal-gpt5.html
+++ b/blog/openai-multimodal-gpt5.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OpenAI's Multimodal GPT-5 Reshapes Creation in 2025</title>
+    <meta name="description" content="A look at how GPT-5 blends text, vision and audio and what it means for creators and businesses." />
+    <meta property="og:title" content="OpenAI's Multimodal GPT-5 Reshapes Creation in 2025" />
+    <meta property="og:description" content="GPT-5 introduces true multimodal reasoning with sprawling context windows and real-time tools." />
+    <meta property="og:image" content="https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d?auto=format&fit=crop&w=1350&q=80" />
+    <link rel="stylesheet" href="../assets/css/styles.css" />
+    <link rel="icon" href="../assets/img/favicon-aj.png" type="image/png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-pb6qQyK5EzB4MZC8BvA/6vNJMkRJ8N6gXl7B+9i1kqdR6Y+uhQevFWFe16T9DzF1zJo1Ge3+Rl4rX9xkTx6Npg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  </head>
+  <body>
+    <header class="header">
+      <a href="../index.html" class="logo" aria-label="Home">
+        <div class="logo-wrapper">
+          <img src="../assets/img/ali-jabbary-logo.png" alt="Ali Jabbary Logo" style="height:42px;" />
+        </div>
+      </a>
+      <nav class="nav">
+        <input type="checkbox" id="menu-toggle" />
+        <label for="menu-toggle" class="menu-icon">&#9776;</label>
+        <ul class="menu">
+          <li><a href="../index.html#subjects">Topics</a></li>
+          <li><a href="../index.html#about">About</a></li>
+          <li><a href="../index.html#testimonials">Testimonials</a></li>
+          <li><a href="../index.html#resources">Resources</a></li>
+          <li><a href="../book.html" class="btn">Book Call</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <article class="blog-post">
+        <h1>OpenAI's Multimodal GPT-5 Reshapes Creation in 2025</h1>
+        <p class="post-meta">April 18, 2025</p>
+        <img src="https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d?auto=format&fit=crop&w=1350&q=80" alt="AI network" />
+        <p>
+          OpenAI's long‑awaited GPT‑5 finally lands with native support for text,
+          images, audio and video in a single interface. The model’s massive
+          128k‑token context window and tighter tool integrations let developers
+          craft rich multi‑modal workflows – think chatbots that watch tutorial
+          videos or agents that interpret financial charts while answering
+          questions.
+        </p>
+        <p>
+          Early adopters report dramatic productivity gains for media creation,
+          customer support and research. The new “canvas” feature lets users drag
+          in files, sketch ideas and converse with GPT‑5 in real time. Combined
+          with enterprise‑grade privacy controls, GPT‑5 is poised to become the
+          default co‑pilot for cross‑media projects.
+        </p>
+        <p>
+          The release also expands OpenAI’s plugin ecosystem, making it easier to
+          connect GPT‑5 to proprietary data or run it on‑prem. With responsible
+          use guardrails baked in, the model strikes a balance between power and
+          compliance.
+        </p>
+        <div class="cta-group">
+          <a class="btn" href="../book.html?subject=large-language-models">Build with GPT‑5</a>
+          <a class="btn" href="../book.html">Book a Strategy Call</a>
+        </div>
+      </article>
+    </main>
+    <footer>
+      <p>&copy; <span id="year"></span> Ali Jabbary. All rights reserved.</p>
+      <div>
+        <a href="https://linkedin.com/" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
+        <a href="https://github.com/" aria-label="GitHub"><i class="fab fa-github"></i></a>
+        <a href="mailto:Light.knight32@gmail.com" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
+      </div>
+    </footer>
+    <button onclick="window.scrollTo({top:0,behavior:'smooth'})" class="back-to-top">↑</button>
+    <script src="../assets/js/main.js"></script>
+  </body>
+</html>

--- a/blog/openai-multimodal-gpt5.html
+++ b/blog/openai-multimodal-gpt5.html
@@ -19,7 +19,7 @@
     <header class="header">
       <a href="../index.html" class="logo" aria-label="Home">
         <div class="logo-wrapper">
-          <img src="../assets/img/ali-jabbary-logo.png" alt="Ali Jabbary Logo" style="height:42px;" />
+          <img src="../assets/img/ali-jabbary-logo.png" alt="Ali Jabbary Logo" />
         </div>
       </a>
       <nav class="nav">
@@ -37,7 +37,7 @@
     <main>
       <article class="blog-post">
         <h1>OpenAI's Multimodal GPT-5 Reshapes Creation in 2025</h1>
-        <p class="post-meta">April 18, 2025</p>
+        <p class="post-meta">April 18, 2025 9:00 AM EST</p>
         <img src="https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d?auto=format&fit=crop&w=1350&q=80" alt="AI network" />
         <p>
           OpenAI's long‑awaited GPT‑5 finally lands with native support for text,
@@ -71,10 +71,10 @@
       <div>
         <a href="https://linkedin.com/" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
         <a href="https://github.com/" aria-label="GitHub"><i class="fab fa-github"></i></a>
-        <a href="mailto:Light.knight32@gmail.com" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
+        <a href="mailto:contact@alijabbary.com" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
       </div>
     </footer>
-    <button onclick="window.scrollTo({top:0,behavior:'smooth'})" class="back-to-top">↑</button>
+    <button class="back-to-top">↑</button>
     <script src="../assets/js/main.js"></script>
   </body>
 </html>

--- a/blog/python-polars-2025.html
+++ b/blog/python-polars-2025.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Python 3.13 & Polars 1.32: Data Science's Fast Lane</title>
+    <meta name="description" content="Highlights from Python 3.13 and the latest Polars release accelerating analytical workflows." />
+    <meta property="og:title" content="Python 3.13 & Polars 1.32: Data Science's Fast Lane" />
+    <meta property="og:description" content="Discover the interactive REPL, slimmer stdlib and blazing-fast DataFrame engine that define 2025's toolchain." />
+    <meta property="og:image" content="https://images.unsplash.com/photo-1517433456452-f9633a875f6f?auto=format&fit=crop&w=1350&q=80" />
+    <link rel="stylesheet" href="../assets/css/styles.css" />
+    <link rel="icon" href="../assets/img/favicon-aj.png" type="image/png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-pb6qQyK5EzB4MZC8BvA/6vNJMkRJ8N6gXl7B+9i1kqdR6Y+uhQevFWFe16T9DzF1zJo1Ge3+Rl4rX9xkTx6Npg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  </head>
+  <body>
+    <header class="header">
+      <a href="../index.html" class="logo" aria-label="Home">
+        <div class="logo-wrapper">
+          <img src="../assets/img/ali-jabbary-logo.png" alt="Ali Jabbary Logo" style="height:42px;" />
+        </div>
+      </a>
+      <nav class="nav">
+        <input type="checkbox" id="menu-toggle" />
+        <label for="menu-toggle" class="menu-icon">&#9776;</label>
+        <ul class="menu">
+          <li><a href="../index.html#subjects">Topics</a></li>
+          <li><a href="../index.html#about">About</a></li>
+          <li><a href="../index.html#testimonials">Testimonials</a></li>
+          <li><a href="../index.html#resources">Resources</a></li>
+          <li><a href="../book.html" class="btn">Book Call</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <article class="blog-post">
+        <h1>Python 3.13 & Polars 1.32: Data Science's Fast Lane</h1>
+        <p class="post-meta">August 20, 2025</p>
+        <img src="https://images.unsplash.com/photo-1517433456452-f9633a875f6f?auto=format&fit=crop&w=1350&q=80" alt="Coding on laptop" />
+        <p>
+          Python 3.13 ships with a revamped interactive interpreter that keeps
+          multiline history and colours errors by default. Obsolete modules have
+          been retired as part of PEP 594, trimming the standard library and
+          making room for faster startup times.
+        </p>
+        <p>
+          On the data side, Polars 1.32 introduces a matured streaming engine and
+          a SQL interface that compiles to its familiar expression API. Joins and
+          group‑bys now leverage adaptive chunking to squeeze even more
+          performance from modern CPUs.
+        </p>
+        <p>
+          Together, Python 3.13 and Polars 1.32 form a lightning‑fast toolkit for
+          notebooks, ETL pipelines and production apps. Early benchmarks show
+          complex analytics running up to 30% quicker than last year’s stack.
+        </p>
+        <div class="cta-group">
+          <a class="btn" href="../book.html?subject=python-data-science">Upgrade My Stack</a>
+          <a class="btn" href="../book.html">Book a Tutoring Session</a>
+        </div>
+      </article>
+    </main>
+    <footer>
+      <p>&copy; <span id="year"></span> Ali Jabbary. All rights reserved.</p>
+      <div>
+        <a href="https://linkedin.com/" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
+        <a href="https://github.com/" aria-label="GitHub"><i class="fab fa-github"></i></a>
+        <a href="mailto:Light.knight32@gmail.com" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
+      </div>
+    </footer>
+    <button onclick="window.scrollTo({top:0,behavior:'smooth'})" class="back-to-top">↑</button>
+    <script src="../assets/js/main.js"></script>
+  </body>
+</html>

--- a/blog/python-polars-2025.html
+++ b/blog/python-polars-2025.html
@@ -19,7 +19,7 @@
     <header class="header">
       <a href="../index.html" class="logo" aria-label="Home">
         <div class="logo-wrapper">
-          <img src="../assets/img/ali-jabbary-logo.png" alt="Ali Jabbary Logo" style="height:42px;" />
+          <img src="../assets/img/ali-jabbary-logo.png" alt="Ali Jabbary Logo" />
         </div>
       </a>
       <nav class="nav">
@@ -37,7 +37,7 @@
     <main>
       <article class="blog-post">
         <h1>Python 3.13 & Polars 1.32: Data Science's Fast Lane</h1>
-        <p class="post-meta">August 20, 2025</p>
+        <p class="post-meta">August 20, 2025 10:00 AM EST</p>
         <img src="https://images.unsplash.com/photo-1517433456452-f9633a875f6f?auto=format&fit=crop&w=1350&q=80" alt="Coding on laptop" />
         <p>
           Python 3.13 ships with a revamped interactive interpreter that keeps
@@ -67,10 +67,10 @@
       <div>
         <a href="https://linkedin.com/" aria-label="LinkedIn"><i class="fab fa-linkedin"></i></a>
         <a href="https://github.com/" aria-label="GitHub"><i class="fab fa-github"></i></a>
-        <a href="mailto:Light.knight32@gmail.com" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
+        <a href="mailto:contact@alijabbary.com" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
       </div>
     </footer>
-    <button onclick="window.scrollTo({top:0,behavior:'smooth'})" class="back-to-top">↑</button>
+    <button class="back-to-top">↑</button>
     <script src="../assets/js/main.js"></script>
   </body>
 </html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,4 +6,16 @@
   <url>
     <loc>https://alijabbary.com/book.html</loc>
   </url>
+  <url>
+    <loc>https://alijabbary.com/blog/</loc>
+  </url>
+  <url>
+    <loc>https://alijabbary.com/blog/openai-multimodal-gpt5.html</loc>
+  </url>
+  <url>
+    <loc>https://alijabbary.com/blog/python-polars-2025.html</loc>
+  </url>
+  <url>
+    <loc>https://alijabbary.com/blog/ai-finance-regulations-2025.html</loc>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add three new HTML blog posts on GPT-5 multimodal release, Python 3.13/Polars updates, and AI finance regulations
- list posts in new blog index and expose metadata via blog-data.js
- expand sitemap with blog paths for better discovery

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a058ae0990832696c369acc2275bf9